### PR TITLE
ci: Actually run doctests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - run: cargo test --workspace --all-features --all-targets
+      - run: cargo test --workspace --all-features
 
   codecov:
     name: Code Coverage


### PR DESCRIPTION
Turns out `--all-targets` does not run doctests.
It is needed to clippy check examples however. Of which we don’t have any, but anyway.