### PR TITLE
Reimplement `StringTable` in terms of `hashbrown::HashTable`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,12 @@ repository = "https://github.com/getsentry/watto"
 [features]
 std = []
 writer = ["std"]
-strings = ["std", "leb128", "thiserror"]
+strings = ["std", "hashbrown", "leb128", "thiserror"]
 
 [dependencies]
+hashbrown = { version = "0.15.1", optional = true }
 leb128 = { version = "0.2.5", optional = true }
-thiserror = { version = "1.0.33", optional = true }
+thiserror = { version = "2.0.3", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/string_table.rs
+++ b/src/string_table.rs
@@ -1,7 +1,10 @@
+use core::fmt;
+use core::hash::BuildHasher;
 use core::str::Utf8Error;
-use std::collections::HashMap;
 use std::io::Cursor;
 
+use hashbrown::hash_table::Entry;
+use hashbrown::{DefaultHashBuilder, HashTable};
 use thiserror::Error;
 
 /// An error when trying to read a string from a serialized [`StringTable`].
@@ -41,10 +44,21 @@ pub enum ReadStringError {
 /// assert_eq!(StringTable::read(string_bytes, foo_offset).unwrap(), "foo");
 /// assert_eq!(StringTable::read(string_bytes, bar_offset).unwrap(), "bar");
 /// ```
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct StringTable {
-    strings: HashMap<String, usize>,
-    bytes: Vec<u8>,
+    hasher: DefaultHashBuilder,
+    offsets: HashTable<usize>,
+    buffer: Vec<u8>,
+}
+
+impl fmt::Debug for StringTable {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let iter = self
+            .offsets
+            .iter()
+            .map(|&offset| (offset, Self::read(&self.buffer, offset).unwrap()));
+        f.debug_map().entries(iter).finish()
+    }
 }
 
 impl StringTable {
@@ -53,37 +67,54 @@ impl StringTable {
         Self::default()
     }
 
+    fn read_bytes(buffer: &[u8], offset: usize) -> Result<(&[u8], usize), ReadStringError> {
+        let mut cursor = Cursor::new(buffer.get(offset..).ok_or(ReadStringError::OutOfBounds)?);
+        let len = leb128::read::unsigned(&mut cursor)? as usize;
+        // it would be nice if `leb128` would directly return this as well,
+        // so one wouldn't have to use a `Cursor`.
+        let leb_len = cursor.position() as usize;
+
+        let start = offset + leb_len;
+        let end = start + len;
+
+        let string_bytes = buffer.get(start..end).ok_or(ReadStringError::OutOfBounds)?;
+
+        Ok((string_bytes, end))
+    }
+
+    fn raw_entry(&mut self, string_bytes: &[u8]) -> (Entry<'_, usize>, &mut Vec<u8>) {
+        let hasher = |val: &_| self.hasher.hash_one(val);
+        let hash = hasher(string_bytes);
+
+        let entry = self.offsets.entry(
+            hash,
+            |&offset| Self::read_bytes(&self.buffer, offset).unwrap().0 == string_bytes,
+            |&offset| hasher(Self::read_bytes(&self.buffer, offset).unwrap().0),
+        );
+        (entry, &mut self.buffer)
+    }
+
     /// Initializes a [`StringTable`] from a previously serialized representation.
     ///
     /// This essentially reverses the [`as_bytes`](Self::as_bytes) call.
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ReadStringError> {
-        let mut rest = bytes;
+    pub fn from_bytes(buffer: &[u8]) -> Result<Self, ReadStringError> {
+        let mut slf = Self {
+            buffer: buffer.into(),
+            ..Default::default()
+        };
 
-        let mut string_offset = 0;
-        let mut strings: HashMap<_, _> = Default::default();
-        while !rest.is_empty() {
-            let mut cursor = Cursor::new(rest);
-            let len = leb128::read::unsigned(&mut cursor)? as usize;
-            // it would be nice if `leb128` would directly return this as well,
-            // so one wouldn't have to use a `Cursor`.
-            let leb_len = cursor.position() as usize;
+        let mut offset = 0;
+        while offset < buffer.len() {
+            let (string_bytes, next_offset) = Self::read_bytes(buffer, offset)?;
+            std::str::from_utf8(string_bytes)?;
 
-            let (string_bytes, new_rest) = rest
-                .split_at_checked(leb_len + len)
-                .ok_or(ReadStringError::OutOfBounds)?;
+            let (entry, _buffer) = slf.raw_entry(string_bytes);
+            entry.insert(offset);
 
-            let string =
-                std::str::from_utf8(&string_bytes[leb_len..]).map_err(ReadStringError::from)?;
-            strings.insert(string.to_owned(), string_offset);
-
-            string_offset += leb_len + len;
-            rest = new_rest;
+            offset = next_offset;
         }
 
-        Ok(Self {
-            strings,
-            bytes: bytes.into(),
-        })
+        Ok(slf)
     }
 
     /// Insert a string into this `StringTable`.
@@ -91,22 +122,26 @@ impl StringTable {
     /// Returns an offset that can be used to retrieve the inserted string
     /// with [`read`](Self::read) after serializing this table with [`as_bytes`](Self::as_bytes).
     pub fn insert(&mut self, s: &str) -> usize {
-        if let Some(&offset) = self.strings.get(s) {
-            return offset;
-        }
-        let string_offset = self.bytes.len();
-        let string_len = s.len() as u64;
-        leb128::write::unsigned(&mut self.bytes, string_len).unwrap();
-        self.bytes.extend_from_slice(s.as_bytes());
+        let string_bytes = s.as_bytes();
+        let (entry, buffer) = self.raw_entry(string_bytes);
 
-        self.strings.insert(s.to_owned(), string_offset);
-        string_offset
+        let entry = entry.or_insert_with(|| {
+            let offset = buffer.len();
+
+            let string_len = string_bytes.len() as u64;
+            leb128::write::unsigned(buffer, string_len).unwrap();
+            buffer.extend_from_slice(string_bytes);
+
+            offset
+        });
+
+        *entry.get()
     }
 
     /// Returns a byte slice containing the concatenation of the strings that have been
     /// added to this `StringTable`.
     pub fn as_bytes(&self) -> &[u8] {
-        &self.bytes
+        &self.buffer
     }
 
     /// Returns a byte vector containing the concatenation of the strings that have been
@@ -114,20 +149,14 @@ impl StringTable {
     ///
     /// This consumes the `StringTable`.
     pub fn into_bytes(self) -> Vec<u8> {
-        self.bytes
+        self.buffer
     }
 
     /// Returns the string stored at the given offset in the byte slice, if any.
     ///
     /// Use this to retrieve a string that was previously [inserted](StringTable::insert) into a `StringTable`.
-    pub fn read(string_bytes: &[u8], offset: usize) -> Result<&str, ReadStringError> {
-        let reader = &mut string_bytes
-            .get(offset..)
-            .ok_or(ReadStringError::OutOfBounds)?;
-        let len = leb128::read::unsigned(reader)? as usize;
-
-        let bytes = reader.get(..len).ok_or(ReadStringError::OutOfBounds)?;
-
-        std::str::from_utf8(bytes).map_err(ReadStringError::from)
+    pub fn read(buffer: &[u8], offset: usize) -> Result<&str, ReadStringError> {
+        let bytes = Self::read_bytes(buffer, offset)?.0;
+        Ok(std::str::from_utf8(bytes)?)
     }
 }


### PR DESCRIPTION
Previously, this was using a `HashMap<String, usize>`, which requires allocating and copying individual `String`s.

Now, this uses the equivalent of a `HashSet<usize>`, where the implementation makes sure that the underlying `hash` and `eq` is using the bytes within the `buffer`. Thus no copy of individual `String`s is required, and allocations are limited to the `buffer` and `offsets`.

---

The implementation could have used [`HashMap::raw_entry_mut`](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.raw_entry_mut) which specifies one of the use-cases as:

> Using custom comparison logic without newtype wrappers

Though that implementation is nightly-only, so I am using [`hashbrown::HashTable`](https://docs.rs/hashbrown/latest/hashbrown/hash_table/struct.HashTable.html) instead, which describes one of the use-cases as:

> An `IndexMap` implementation where indices into a `Vec` are stored as elements in a `HashTable<usize>`. Hashing and comparing the elements requires indexing the associated `Vec` to get the actual value referred to by the index.

This is exactly what we are doing here. Hashing and comparing the elements requires looking into the `buffer` to get the actual value referred by the offset.