### PR TITLE
Add `OffsetSet` as a more generic version of `StringTable`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ repository = "https://github.com/getsentry/watto"
 [features]
 std = []
 writer = ["std"]
-strings = ["std", "hashbrown", "leb128", "thiserror"]
+offset_set = ["std", "dep:hashbrown", "dep:leb128", "dep:thiserror"]
+strings = ["offset_set"]
 
 [dependencies]
 hashbrown = { version = "0.15.1", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg_hide))]
 #![cfg_attr(docsrs, doc(cfg_hide(doc)))]
 
+#[cfg(feature = "offset_set")]
+mod offset_set;
 mod pod;
 #[cfg(feature = "strings")]
 mod string_table;
@@ -12,6 +14,8 @@ mod utils;
 #[cfg(feature = "writer")]
 mod writer;
 
+#[cfg(feature = "offset_set")]
+pub use offset_set::*;
 pub use pod::*;
 #[cfg(feature = "strings")]
 pub use string_table::*;

--- a/src/offset_set.rs
+++ b/src/offset_set.rs
@@ -1,0 +1,193 @@
+use core::hash::{BuildHasher, Hash};
+use core::marker::PhantomData;
+use core::{fmt, mem};
+use std::io::Cursor;
+
+use hashbrown::hash_table::Entry;
+use hashbrown::{DefaultHashBuilder, HashTable};
+use thiserror::Error;
+
+use crate::Pod;
+
+/// An error when trying to read a slice from a serialized [`OffsetSet`].
+#[derive(Debug, Error)]
+pub enum ReadOffsetSetError {
+    /// The entry's length prefix is not valid LEB128.
+    #[error("error reading LEB128 encoded number")]
+    Leb128(#[from] leb128::read::Error),
+    /// The entry's offset or length is outside the bounds of the data blob.
+    #[error("element offset or length is out of bounds")]
+    OutOfBounds,
+}
+
+/// A struct for storing arbitrary slices without duplicates.
+///
+/// The [`OffsetSet`] can be thought of as a specialized version of
+/// [`IndexSet<&[T]>`](https://docs.rs/indexmap/latest/indexmap/set/struct.IndexSet.html),
+/// with the following differences:
+///
+/// - It is specialized to store slices of `T`.
+/// - It does not return an *index*, but rather an *offset* of the encoded slice
+///   within the buffer.
+/// - It is intended to be serialized as an opaque buffer, and data to be loaded
+///   from it with minimal overhead.
+#[derive(Clone)]
+pub struct OffsetSet<T> {
+    hasher: DefaultHashBuilder,
+    offsets: HashTable<usize>,
+    buffer: Vec<u8>,
+    _t: PhantomData<T>,
+}
+
+impl<T: fmt::Debug + Pod> fmt::Debug for OffsetSet<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_map().entries(self.entries()).finish()
+    }
+}
+
+impl<T> Default for OffsetSet<T> {
+    fn default() -> Self {
+        Self {
+            hasher: Default::default(),
+            offsets: Default::default(),
+            buffer: Default::default(),
+            _t: Default::default(),
+        }
+    }
+}
+
+impl<T: Pod> OffsetSet<T> {
+    #[doc(hidden)]
+    const _ALIGN_OF_T: () = {
+        // TODO: this is not a hard requirement for now, and we can lift this in the future.
+        // - using `leb128` encoding might not make sense at all for types with larger alignment
+        // - otherwise this might be missing a couple of places that need explicit alignment
+        // - and as we have found out, miri is particularly picky about alignment as well :-)
+        assert!(
+            mem::align_of::<T>() == 1,
+            "T is currently limited to alignment `1`"
+        )
+    };
+
+    /// Initializes an empty [`OffsetSet`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the slice stored at the given offset in the byte slice, if any.
+    ///
+    /// Use this to retrieve a slice that was previously [inserted](OffsetSet::insert) into an [`OffsetSet`].
+    pub fn read(buffer: &[u8], offset: usize) -> Result<&[T], ReadOffsetSetError> {
+        Ok(OffsetSet::read_internal(buffer, offset)?.0)
+    }
+
+    fn read_internal(buffer: &[u8], offset: usize) -> Result<(&[T], usize), ReadOffsetSetError> {
+        let mut cursor = Cursor::new(
+            buffer
+                .get(offset..)
+                .ok_or(ReadOffsetSetError::OutOfBounds)?,
+        );
+        let len = leb128::read::unsigned(&mut cursor)? as usize;
+        // it would be nice if `leb128` would directly return this as well,
+        // so one wouldn't have to use a `Cursor`.
+        let leb_len = cursor.position() as usize;
+
+        let start = offset + leb_len;
+        let end = start + len * mem::size_of::<T>();
+
+        let bytes = buffer
+            .get(start..end)
+            .ok_or(ReadOffsetSetError::OutOfBounds)?;
+        let slice = T::slice_from_bytes(bytes).ok_or(ReadOffsetSetError::OutOfBounds)?;
+
+        Ok((slice, end))
+    }
+
+    /// Iterates over all the entries is this [`OffsetSet`].
+    ///
+    /// This yields `(offset, slice)` pairs.
+    pub fn entries(&self) -> impl Iterator<Item = (usize, &[T])> + '_ {
+        self.offsets
+            .iter()
+            .map(|&offset| (offset, Self::read(&self.buffer, offset).unwrap()))
+    }
+
+    /// Returns a byte slice containing the serialized representation of this [`OffsetSet`].
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.buffer
+    }
+
+    /// Returns a byte vector containing the serialized representation of this [`OffsetSet`].
+    ///
+    /// This consumes the [`OffsetSet`].
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.buffer
+    }
+}
+
+impl<T: Pod + PartialEq + Hash> OffsetSet<T> {
+    fn raw_entry(&mut self, items: &[T]) -> (Entry<'_, usize>, &mut Vec<u8>) {
+        let hasher = |val: &_| self.hasher.hash_one(val);
+        let hash = hasher(items);
+
+        let entry = self.offsets.entry(
+            hash,
+            |&offset| Self::read(&self.buffer, offset).unwrap() == items,
+            |&offset| hasher(Self::read(&self.buffer, offset).unwrap()),
+        );
+        (entry, &mut self.buffer)
+    }
+
+    /// Initializes an [`OffsetSet`] from a previously serialized representation.
+    ///
+    /// This essentially reverses the [`as_bytes`](Self::as_bytes) call.
+    pub fn from_bytes(buffer: &[u8]) -> Result<Self, ReadOffsetSetError> {
+        Self::from_bytes_validated(buffer, |_| Ok(()))
+    }
+
+    /// Initializes an [`OffsetSet`] from a previously serialized representation,
+    /// running each loaded slice through a validation function.
+    pub fn from_bytes_validated<V, E>(buffer: &[u8], validate: V) -> Result<Self, E>
+    where
+        E: From<ReadOffsetSetError>,
+        V: Fn(&[T]) -> Result<(), E>,
+    {
+        let mut slf = Self {
+            buffer: buffer.into(),
+            ..Default::default()
+        };
+
+        let mut offset = 0;
+        while offset < buffer.len() {
+            let (item, next_offset) = Self::read_internal(buffer, offset)?;
+            validate(item)?;
+
+            let (entry, _buffer) = slf.raw_entry(item);
+            entry.insert(offset);
+
+            offset = next_offset;
+        }
+
+        Ok(slf)
+    }
+
+    /// Insert a string into this [`OffsetSet`].
+    ///
+    /// Returns an offset that can be used to retrieve the inserted input
+    /// with [`read`](Self::read) after serializing this table with [`as_bytes`](Self::as_bytes).
+    pub fn insert(&mut self, input: &[T]) -> usize {
+        let (entry, buffer) = self.raw_entry(input);
+
+        let entry = entry.or_insert_with(|| {
+            let offset = buffer.len();
+
+            let len = input.len() as u64;
+            leb128::write::unsigned(buffer, len).unwrap();
+            buffer.extend_from_slice(input.as_bytes());
+
+            offset
+        });
+
+        *entry.get()
+    }
+}

--- a/src/string_table.rs
+++ b/src/string_table.rs
@@ -1,11 +1,9 @@
 use core::fmt;
-use core::hash::BuildHasher;
 use core::str::Utf8Error;
-use std::io::Cursor;
 
-use hashbrown::hash_table::Entry;
-use hashbrown::{DefaultHashBuilder, HashTable};
 use thiserror::Error;
+
+use crate::{OffsetSet, ReadOffsetSetError};
 
 /// An error when trying to read a string from a serialized [`StringTable`].
 #[derive(Debug, Error)]
@@ -19,6 +17,15 @@ pub enum ReadStringError {
     /// The string's offset or length is outside the bounds of the data blob.
     #[error("string offset or length is out of bounds")]
     OutOfBounds,
+}
+
+impl From<ReadOffsetSetError> for ReadStringError {
+    fn from(value: ReadOffsetSetError) -> Self {
+        match value {
+            ReadOffsetSetError::Leb128(error) => Self::Leb128(error),
+            ReadOffsetSetError::OutOfBounds => Self::OutOfBounds,
+        }
+    }
 }
 
 /// A struct for storing strings without duplicates.
@@ -46,17 +53,15 @@ pub enum ReadStringError {
 /// ```
 #[derive(Clone, Default)]
 pub struct StringTable {
-    hasher: DefaultHashBuilder,
-    offsets: HashTable<usize>,
-    buffer: Vec<u8>,
+    inner: OffsetSet<u8>,
 }
 
 impl fmt::Debug for StringTable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let iter = self
-            .offsets
-            .iter()
-            .map(|&offset| (offset, Self::read(&self.buffer, offset).unwrap()));
+            .inner
+            .entries()
+            .map(|(offset, string_bytes)| (offset, std::str::from_utf8(string_bytes).unwrap()));
         f.debug_map().entries(iter).finish()
     }
 }
@@ -67,54 +72,18 @@ impl StringTable {
         Self::default()
     }
 
-    fn read_bytes(buffer: &[u8], offset: usize) -> Result<(&[u8], usize), ReadStringError> {
-        let mut cursor = Cursor::new(buffer.get(offset..).ok_or(ReadStringError::OutOfBounds)?);
-        let len = leb128::read::unsigned(&mut cursor)? as usize;
-        // it would be nice if `leb128` would directly return this as well,
-        // so one wouldn't have to use a `Cursor`.
-        let leb_len = cursor.position() as usize;
-
-        let start = offset + leb_len;
-        let end = start + len;
-
-        let string_bytes = buffer.get(start..end).ok_or(ReadStringError::OutOfBounds)?;
-
-        Ok((string_bytes, end))
-    }
-
-    fn raw_entry(&mut self, string_bytes: &[u8]) -> (Entry<'_, usize>, &mut Vec<u8>) {
-        let hasher = |val: &_| self.hasher.hash_one(val);
-        let hash = hasher(string_bytes);
-
-        let entry = self.offsets.entry(
-            hash,
-            |&offset| Self::read_bytes(&self.buffer, offset).unwrap().0 == string_bytes,
-            |&offset| hasher(Self::read_bytes(&self.buffer, offset).unwrap().0),
-        );
-        (entry, &mut self.buffer)
-    }
-
     /// Initializes a [`StringTable`] from a previously serialized representation.
     ///
     /// This essentially reverses the [`as_bytes`](Self::as_bytes) call.
     pub fn from_bytes(buffer: &[u8]) -> Result<Self, ReadStringError> {
-        let mut slf = Self {
-            buffer: buffer.into(),
-            ..Default::default()
-        };
-
-        let mut offset = 0;
-        while offset < buffer.len() {
-            let (string_bytes, next_offset) = Self::read_bytes(buffer, offset)?;
-            std::str::from_utf8(string_bytes)?;
-
-            let (entry, _buffer) = slf.raw_entry(string_bytes);
-            entry.insert(offset);
-
-            offset = next_offset;
-        }
-
-        Ok(slf)
+        let inner =
+            OffsetSet::from_bytes_validated(buffer, |string_bytes| {
+                match std::str::from_utf8(string_bytes) {
+                    Ok(_) => Ok(()),
+                    Err(err) => Err(ReadStringError::Utf8(err)),
+                }
+            })?;
+        Ok(Self { inner })
     }
 
     /// Insert a string into this `StringTable`.
@@ -122,26 +91,13 @@ impl StringTable {
     /// Returns an offset that can be used to retrieve the inserted string
     /// with [`read`](Self::read) after serializing this table with [`as_bytes`](Self::as_bytes).
     pub fn insert(&mut self, s: &str) -> usize {
-        let string_bytes = s.as_bytes();
-        let (entry, buffer) = self.raw_entry(string_bytes);
-
-        let entry = entry.or_insert_with(|| {
-            let offset = buffer.len();
-
-            let string_len = string_bytes.len() as u64;
-            leb128::write::unsigned(buffer, string_len).unwrap();
-            buffer.extend_from_slice(string_bytes);
-
-            offset
-        });
-
-        *entry.get()
+        self.inner.insert(s.as_bytes())
     }
 
     /// Returns a byte slice containing the concatenation of the strings that have been
     /// added to this `StringTable`.
     pub fn as_bytes(&self) -> &[u8] {
-        &self.buffer
+        self.inner.as_bytes()
     }
 
     /// Returns a byte vector containing the concatenation of the strings that have been
@@ -149,14 +105,14 @@ impl StringTable {
     ///
     /// This consumes the `StringTable`.
     pub fn into_bytes(self) -> Vec<u8> {
-        self.buffer
+        self.inner.into_bytes()
     }
 
     /// Returns the string stored at the given offset in the byte slice, if any.
     ///
     /// Use this to retrieve a string that was previously [inserted](StringTable::insert) into a `StringTable`.
     pub fn read(buffer: &[u8], offset: usize) -> Result<&str, ReadStringError> {
-        let bytes = Self::read_bytes(buffer, offset)?.0;
+        let bytes = OffsetSet::read(buffer, offset)?;
         Ok(std::str::from_utf8(bytes)?)
     }
 }


### PR DESCRIPTION
The new `OffsetSet<T>` corresponds roughly to `IndexSet<&[T]>`. This way, `StringTable` internally becomes a `OffsetSet<u8>`, as `&str` is just `&[u8]`, with some added utf-8 validation.