### PR TITLE
chore(ci): Pin macOS runner to macos-15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-15, windows-latest]
 
     name: Rust Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -78,7 +78,7 @@ pub unsafe trait Pod {
         let len = bytes.len();
         let elem_size = mem::size_of::<Self>();
 
-        if len % elem_size != 0 || !crate::utils::is_aligned_to(bytes, mem::align_of::<Self>()) {
+        if !len.is_multiple_of(elem_size) || !crate::utils::is_aligned_to(bytes, mem::align_of::<Self>()) {
             return None;
         }
 

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -78,7 +78,9 @@ pub unsafe trait Pod {
         let len = bytes.len();
         let elem_size = mem::size_of::<Self>();
 
-        if !len.is_multiple_of(elem_size) || !crate::utils::is_aligned_to(bytes, mem::align_of::<Self>()) {
+        if !len.is_multiple_of(elem_size)
+            || !crate::utils::is_aligned_to(bytes, mem::align_of::<Self>())
+        {
             return None;
         }
 


### PR DESCRIPTION
GitHub is migrating the macos-latest label to the macOS 26 runner image, rolling out between June 15 and July 15, 2026. Pin the test matrix to macos-15 to stay on the current stable image.